### PR TITLE
Add setting to ignore dates in codeblocks and update dependencies

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1115,7 +1115,7 @@ class DatepickerSettingTab extends PluginSettingTab {
 
 		new Setting(settingsContainerElement)
 			.setName('Ignore dates in codeblocks')
-			.setDesc('When enabled, the datepicker will ignore dates inside markdown codeblocks (both inline code and fenced code blocks)')
+			.setDesc('When enabled, the datepicker will ignore dates inside markdown codeblocks (both inline code and fenced code blocks, Reloading Obsidian may be required)')
 			.addToggle((toggle) => toggle
 				.setValue(DatepickerPlugin.settings.ignoreCodeblocks)
 				.onChange(async (value) => {

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,7 @@ import {
 	Decoration,
 	DecorationSet
 } from "@codemirror/view";
+import { syntaxTree } from "@codemirror/language";
 import { platform } from 'os';
 
 interface DateMatch {
@@ -171,6 +172,32 @@ class DatepickerCMPlugin implements PluginValue {
 		return formats;
 	}
 
+	private isInCodeblock(view: EditorView, position: number): boolean {
+		// If the setting is disabled, never consider any position to be in a codeblock
+		if (!DatepickerPlugin.settings.ignoreCodeblocks) {
+			return false;
+		}
+		
+		const tree = syntaxTree(view.state);
+		let node: any = tree.resolve(position);
+		
+		// Traverse up the syntax tree to find if we're inside a codeblock
+		while (node) {
+			// Check for fenced code blocks (```) or inline code (`)
+			if (node.name === 'FencedCode' || 
+				node.name === 'CodeBlock' || 
+				node.name === 'InlineCode' ||
+				node.name === 'CodeText' ||
+				// Additional checks for different markdown parsers
+				node.name.includes('Code') ||
+				node.name.includes('code')) {
+				return true;
+			}
+			node = node.parent;
+		}
+		return false;
+	}
+
 
 	private getVisibleDates(view: EditorView): DateMatch[] {
 		let visibleText: VisibleText[] = [];
@@ -184,6 +211,10 @@ class DatepickerCMPlugin implements PluginValue {
 					while ((matchingDate = format.regex.exec(vt.text ?? "")) !== null) {
 						const matchingDateStart = matchingDate?.index! + vt.from;
 						const matchingDateEnd = matchingDate?.index! + matchingDate![0].length + vt.from;
+						
+						// Skip dates that are inside codeblocks
+						if (this.isInCodeblock(view, matchingDateStart)) continue;
+						
 						/*
 						 avoid pushing values that are part of another match to avoid recognizing values that are part of other values
 						 as their own date/time, eg: the time portion of a date/time is not seperate from the date portion, two dates on
@@ -206,6 +237,10 @@ class DatepickerCMPlugin implements PluginValue {
 			while ((matchingDate = format.regex.exec(noteText)) !== null) {
 				const matchingDateStart = matchingDate?.index!;
 				const matchingDateEnd = matchingDate?.index! + matchingDate![0].length;
+				
+				// Skip dates that are inside codeblocks
+				if (this.isInCodeblock(view, matchingDateStart)) continue;
+				
 				if (dateMatches.some((m) =>
 					matchingDateStart >= m.from && ((matchingDateEnd <= m.to) || (matchingDateStart <= m.to)))) continue;
 				dateMatches.push({ from: matchingDate.index, to: matchingDate.index + matchingDate[0].length, value: matchingDate[0], format: format });
@@ -449,6 +484,7 @@ interface DatepickerPluginSettings {
 	focusOnArrowDown: boolean;
 	insertIn24HourFormat: boolean;
 	selectDateText: boolean;
+	ignoreCodeblocks: boolean;
 }
 
 const DEFAULT_SETTINGS: DatepickerPluginSettings = {
@@ -462,7 +498,8 @@ const DEFAULT_SETTINGS: DatepickerPluginSettings = {
 	autofocus: false,
 	focusOnArrowDown: false,
 	insertIn24HourFormat: false,
-	selectDateText: false
+	selectDateText: false,
+	ignoreCodeblocks: false
 }
 
 export default class DatepickerPlugin extends Plugin {
@@ -1073,6 +1110,16 @@ class DatepickerSettingTab extends PluginSettingTab {
 				.setValue(DatepickerPlugin.settings.showTimeButtons)
 				.onChange(async (value) => {
 					DatepickerPlugin.settings.showTimeButtons = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(settingsContainerElement)
+			.setName('Ignore dates in codeblocks')
+			.setDesc('When enabled, the datepicker will ignore dates inside markdown codeblocks (both inline code and fenced code blocks)')
+			.addToggle((toggle) => toggle
+				.setValue(DatepickerPlugin.settings.ignoreCodeblocks)
+				.onChange(async (value) => {
+					DatepickerPlugin.settings.ignoreCodeblocks = value;
 					await this.plugin.saveSettings();
 				}));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.3.24",
 			"license": "MIT",
 			"devDependencies": {
-				"@codemirror/language": "^6.0.0",
+				"@codemirror/language": "^6.11.2",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.3.24",
 			"license": "MIT",
 			"devDependencies": {
+				"@codemirror/language": "^6.0.0",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
@@ -19,13 +20,27 @@
 				"typescript": "4.7.4"
 			}
 		},
+		"node_modules/@codemirror/language": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+			"integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.1.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
 		"node_modules/@codemirror/state": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
 			"integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@codemirror/view": {
 			"version": "6.28.2",
@@ -33,7 +48,6 @@
 			"integrity": "sha512-A3DmyVfjgPsGIjiJqM/zvODUAPQdQl3ci0ghehYNnbt5x+o76xq+dL5+mMBuysDXnI3kapgOkoeJ0sbtL/3qPw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.4.0",
 				"style-mod": "^4.1.0",
@@ -518,6 +532,33 @@
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true
+		},
+		"node_modules/@lezer/common": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2199,8 +2240,7 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2325,8 +2365,7 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@codemirror/language": "^6.0.0",
+		"@codemirror/language": "^6.11.2",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@codemirror/language": "^6.0.0",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",


### PR DESCRIPTION
This feature allows users to prevent the datepicker from interfering with dates that appear in code examples or inline code snippets within markdown documents.

Details:
- Add isInCodeblock method to detect if cursor position is inside markdown codeblocks
- Add ignoreCodeblocks setting to DatepickerPlugin interface and default settings
- Add setting UI toggle to control codeblock ignoring behavior
- Skip date matching when inside fenced code blocks, inline code, or other code elements
- Import syntaxTree from @codemirror/language for syntax analysis
- Add @codemirror/language dependency to package.json

